### PR TITLE
Fix uninitialized variable build warns -> errors

### DIFF
--- a/libpore/sbe_xip_image.c
+++ b/libpore/sbe_xip_image.c
@@ -1628,9 +1628,11 @@ sbe_xip_normalize(void* io_image)
     int rc, i;
     SbeXipSection section;
     SbeXipToc* imageToc;
-    SbeXipHashedToc* fixedImageToc;
-    SbeXipHashedToc* fixedTocEntry;
-    size_t tocEntries, fixedTocEntries, fixedEntriesRemaining;
+    SbeXipHashedToc* fixedImageToc = NULL;
+    SbeXipHashedToc* fixedTocEntry = NULL;
+    size_t tocEntries = 0;
+    size_t fixedTocEntries = 0;
+    size_t fixedEntriesRemaining = 0;
        
     do {
         rc = xipQuickCheck(io_image, 0);


### PR DESCRIPTION
Not sure if this is just a toolchain quirk, but without this I can't get skiboot to build without this.