### PR TITLE
Make links target reusable

### DIFF
--- a/external/common/rules.mk
+++ b/external/common/rules.mk
@@ -17,6 +17,30 @@ endif
 endif
 endif
 
+# Use make V=1 for a verbose build.
+ifndef V
+        Q_CC=	@echo '    CC ' $@;
+        Q_LINK=	@echo '  LINK ' $@;
+        Q_LN=   @echo '    LN ' $@;
+        Q_MKDIR=@echo ' MKDIR ' $@;
+endif
+
+
+.PHONY: links
+links: libflash ccan common
+
+libflash:
+	$(Q_LN)ln -sf ../../libflash ./libflash
+
+ccan:
+	$(Q_LN)ln -sf ../../ccan ./ccan
+
+common:
+	$(Q_LN)ln -sf ../common ./common
+
+make_version.sh:
+	$(Q_LN)ln -sf ../../make_version.sh
+
 ARCH_SRC := $(addprefix common/,$(ARCH_FILES))
 ARCH_OBJS := $(addprefix common-,$(ARCH_FILES:.c=.o))
 

--- a/external/gard/Makefile
+++ b/external/gard/Makefile
@@ -3,28 +3,16 @@ include rules.mk
 GET_ARCH = ../../external/common/get_arch.sh
 include ../../external/common/rules.mk
 
-all: $(EXE)
+all: links $(EXE)
 
-.PHONY: links
-links: libflash ccan common make_version.sh
-
-libflash:
-	ln -sf ../../libflash .
-
-ccan:
-	ln -sf ../../ccan .
-
-common:
-	ln -sf ../common .
-
-make_version.sh:
-	ln -sf ../../make_version.sh
 
 #Rebuild version.o so that the the version always matches
 #what the test suite will get from ./make_version.sh
 check: version.o all
 	@ln -sf ../../test/test.sh test/test.sh
 	@test/test-gard
+
+links += make_version.sh
 
 $(OBJS): | links arch_links
 

--- a/external/opal-prd/Makefile
+++ b/external/opal-prd/Makefile
@@ -10,18 +10,10 @@ sbindir = $(prefix)/sbin
 datadir = $(prefix)/share
 mandir = $(datadir)/man
 
-all: opal-prd
+all: links arch_links | opal-prd
 
 GET_ARCH = ../../external/common/get_arch.sh
 include ../../external/common/rules.mk
-
-# Use make V=1 for a verbose build.
-ifndef V
-        Q_CC=	@echo '    CC ' $@;
-        Q_LINK=	@echo '  LINK ' $@;
-        Q_LN=   @echo '    LN ' $@;
-        Q_MKDIR=@echo ' MKDIR ' $@;
-endif
 
 LIBFLASH_OBJS = libflash-blocklevel.o libflash-libffs.o \
                 libflash-libflash.o libflash-ecc.o \
@@ -30,29 +22,16 @@ LIBFLASH_OBJS = libflash-blocklevel.o libflash-libffs.o \
 OBJS = opal-prd.o thunk.o pnor.o i2c.o module.o version.o \
        $(LIBFLASH_OBJS) common-arch_flash.o
 
-LINKS = ccan common libflash $(ARCH_LINKS)
-
 OPAL_PRD_VERSION ?= $(shell ../../make_version.sh opal-prd)
 
 ifdef KERNEL_DIR
-LINKS += asm/opal-prd.h
+links += asm/opal-prd.h
 endif
-
-ccan:
-	$(Q_LN)ln -sfr ../../ccan ./ccan
-
-libflash:
-	$(Q_LN)ln -sfr ../../libflash ./libflash
-
-common:
-	$(Q_LN)ln -sfr ../common ./common
 
 asm/opal-prd.h:
 	$(Q_MKDIR)mkdir -p asm
 	$(Q_LN)ln -sfr $(KERNEL_DIR)/arch/powerpc/include/uapi/asm/opal-prd.h \
 			asm/opal-prd.h
-
-$(OBJS): | $(LINKS)
 
 %.o: %.c
 	$(Q_CC)$(COMPILE.c) $< -o $@


### PR DESCRIPTION
Move symlinking target to external/common/rules.mk, so the rule
could be reused by gard and opal-prd.

Fixes https://github.com/open-power/skiboot/issues/27 
tested by 100 builds with -j80

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/skiboot/28)
<!-- Reviewable:end -->
