### PR TITLE
Always display full 16 digit scom data

### DIFF
--- a/external/xscom-utils/getscom.c
+++ b/external/xscom-utils/getscom.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr,"Error %d reading XSCOM\n", rc);
 		exit(1);
 	}
-	printf("%" PRIx64 "\n", val);
+	printf("%016" PRIx64 "\n", val);
 	return 0;
 }
 

--- a/external/xscom-utils/putscom.c
+++ b/external/xscom-utils/putscom.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr,"Error %d reading XSCOM\n", rc);
 		exit(1);
 	}
-	printf("%" PRIx64 "\n", val);
+	printf("%016" PRIx64 "\n", val);
 	return 0;
 }
 


### PR DESCRIPTION
There have been several cases of confusion due to the output
from the scom commands being truncated into right-justified
integer representations.  This modifies the output to always
display the complete 64-bit/16-digit register content when
doing scoms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/skiboot/29)
<!-- Reviewable:end -->
