### PR TITLE
pflash and opal-prd: Fix dist-clean

### DIFF
--- a/external/opal-prd/Makefile
+++ b/external/opal-prd/Makefile
@@ -71,3 +71,4 @@ clean:
 
 distclean: clean
 	$(RM) -f $(LINKS) asm
+	$(RM) -f libflash ccan version.c .version common

--- a/external/pflash/Makefile
+++ b/external/pflash/Makefile
@@ -30,5 +30,5 @@ clean: arch_clean
 .PHONY: distclean
 distclean: clean
 	rm -f *.c~ *.h~ *.sh~ Makefile~ config.mk~ libflash/*.c~ libflash/*.h~
-	rm -f libflash ccan .version .version.tmp
+	rm -f libflash ccan version.c .version .version.tmp
 	rm -f common io.h


### PR DESCRIPTION
Currently pflash and opal-prd do not return to its original tree
after a 'make distclean'. I understand that distclean should return the tree to
its original state, so, the make can restart from scratch.

On Debian[1], we need to clear these remaining file 'manually' to make the
build 'reproducible' (two builds in sequence).

[1] https://packages.debian.org/source/sid/skiboot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/skiboot/39)
<!-- Reviewable:end -->
