### PR TITLE
remove 'update mode for partitions' from TODO list

### DIFF
--- a/external/pflash/TODO
+++ b/external/pflash/TODO
@@ -3,5 +3,3 @@
 - Use IPMI for lock/unlock on host
 - Timeouts and flashing errors handling
 - Lock handling
-- Support pnor "update" mode which only update selected partitions
-


### PR DESCRIPTION
Remove 'Support pnor "update" mode which only update selected partitions'
from TODO list as pflash supports --partition=part_name already
Signed-off-by: Werner Fischer <wfischer@thomas-krenn.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/skiboot/56)
<!-- Reviewable:end -->
