### PR TITLE
Add prepare_hbrt_update to hbrt interfaces

### DIFF
--- a/external/opal-prd/hostboot-interface.h
+++ b/external/opal-prd/hostboot-interface.h
@@ -683,6 +683,19 @@ struct runtime_interfaces {
 	 */
 	void (*firmware_notify)(uint64_t len, void *data);
 
+        /**
+         *  @brief Prepare for HBRT concurrent code update
+         *
+         *  @details  This call allows the Host to inform HBRT that a concurrent
+         *  code update has been initiated.  HBRT then prepares updated targeting
+         *  data for use by the updated HBRT code.
+         *
+         *  @return        0 on success else return code
+         *  @platform FSP
+         */
+        int (*prepare_hbrt_update)( void );
+
+
 	/* Reserve some space for future growth. */
-	void (*reserved[22])(void);
+	void (*reserved[21])(void);
 };

--- a/external/opal-prd/thunk.S
+++ b/external/opal-prd/thunk.S
@@ -100,6 +100,7 @@ call_##name:					;\
 	CALL_THUNK(reset_pm_complex, 19)
 	CALL_THUNK(get_ipoll_events, 20)
 	CALL_THUNK(firmware_notify, 21)
+	CALL_THUNK(prepare_hbrt_update, 22)
 
 	.globl call_hbrt_init
 call_hbrt_init:


### PR DESCRIPTION
Add placeholder support for prepare_hbrt_update call into
hostboot runtime (opal-prd) code.  This interface is only
called as part of a concurrent code update on a FSP based
system.

Signed-off-by: Dan Crowell <dcrowell@us.ibm.com>