### PR TITLE
Increase dpath string in i2c.c

### DIFF
--- a/external/opal-prd/i2c.c
+++ b/external/opal-prd/i2c.c
@@ -211,7 +211,7 @@ void i2c_init(void)
 #define SYSFS	"/sys"	/* XXX Find it ? */
 	DIR *devsdir;
 	struct dirent *devent;
-	char dpath[NAME_MAX];
+	char dpath[300];
 	char busname[256];
 	char *s;
 	FILE *f;


### PR DESCRIPTION
increase dpath string in opal-prd/i2c.c

to avoid opal-prd build error:
```
i2c.c:237:40: note: format string is defined here
   sprintf(dpath, SYSFS "/class/i2c-dev/%s/name", devent->d_name);
                                        ^~
i2c.c:237:3: note: 'sprintf' output between 25 and 280 bytes into a destination of size 255
   sprintf(dpath, SYSFS "/class/i2c-dev/%s/name", devent->d_name);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Michel Normand <michel.mno@free.fr>