### PR TITLE
Make gard display show that a record is cleared

### DIFF
--- a/external/gard/gard.c
+++ b/external/gard/gard.c
@@ -488,11 +488,12 @@ static int do_list(struct gard_ctx *ctx, int argc, char **argv)
 	draw_ruler('-', ruler_size);
 
 	for_each_gard(ctx, pos, &gard, &rc) {
-		printf(" %08x | %08x | %-10s | %s\n",
+		printf(" %08x | %08x | %-10s | %s%s\n",
 			be32toh(gard.record_id),
 			be32toh(gard.errlog_eid),
 			deconfig_reason_str(gard.error_type),
-			format_path(&gard.target_id, scratch));
+			format_path(&gard.target_id, scratch),
+                        gard.record_id == 0xffffffff ? " *CLEARED*" : "");
 	}
 
 	draw_ruler('=', ruler_size);
@@ -515,7 +516,7 @@ static int do_show_i(struct gard_ctx *ctx, int pos, struct gard_record *gard, vo
 	if (be32toh(gard->record_id) == id) {
 		unsigned int count, i;
 
-		printf("Record ID:    0x%08x\n", id);
+		printf("Record ID:    0x%08x%s\n", id, id == 0xffffffff ? " *CLEARED*" : "");
 		printf("========================\n");
 		printf("Error ID:     0x%08x\n", be32toh(gard->errlog_eid));
 		printf("Error Type:   %s (0x%02x)\n",


### PR DESCRIPTION
When clearing gard records, Hostboot only modifies the record_id
portion to be 0xFFFFFFFF.  The remainder of the entry remains.
Without this change it can be confusing to users to know that
the record they are looking at is no longer valid.