### PR TITLE
p9dsu: Fix p9dsu slot tables

### DIFF
--- a/platforms/astbmc/p9dsu.c
+++ b/platforms/astbmc/p9dsu.c
@@ -355,25 +355,25 @@ static const struct slot_table_entry p9dsu2uess_uio_plx_down[] = {
 		.power_limit = 75,
 	},
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0x8,0),
-		.name = "PLX switch UIO Slot2",
+		.name = "PLX SWITCH UIO Slot2",
 		.power_limit = 75,
 	},
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0x9,0),
-		.name = "PLX Down Onboard LAN UIO Slot2",
+		.name = "PLX DOWN LAN UIO Slot2",
 	},
 	{ .etype = st_end },
 };
 
 static const struct slot_table_entry p9dsu2uess_uio_plx_up[] = {
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0,0),
 		.children = p9dsu2uess_uio_plx_down,
-		.name = "PLX up UIO Slot2",
+		.name = "PLX UP UIO Slot2",
 		.power_limit = 75,
 	},
 	{ .etype = st_end },
@@ -387,9 +387,9 @@ static const struct slot_table_entry p9dsu2uess_wio_plx_down[] = {
 		.power_limit = 75,
 	},
     	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0x8,0),
-		.name = "PLX switch WIO Slot3",
+		.name = "PLX SWITCH WIO Slot3",
 		.power_limit = 75,
 	},
 	{
@@ -403,10 +403,10 @@ static const struct slot_table_entry p9dsu2uess_wio_plx_down[] = {
 
 static const struct slot_table_entry p9dsu2uess_wio_plx_up[] = {
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0,0),
 		.children = p9dsu2uess_wio_plx_down,
-		.name = "PLX up WIO Slot3",
+		.name = "PLX UP WIO Slot3",
 		.power_limit = 75,
 	},
 	{ .etype = st_end },
@@ -424,8 +424,8 @@ static const struct slot_table_entry p9dsu2uess_phb0_0_slot[] = {
 
 static const struct slot_table_entry p9dsu2uess_phb0_1_slot[] = {
 	{
-		.etype = st_builtin_dev,
-		.location = ST_LOC_DEVFN(0x1,0),
+		.etype = st_pluggable_slot,
+		.location = ST_LOC_DEVFN(0,0),
 		.children = p9dsu2uess_uio_plx_up,
 		.name = "PLX UIO Slot2",
 		.power_limit = 75,
@@ -435,7 +435,7 @@ static const struct slot_table_entry p9dsu2uess_phb0_1_slot[] = {
 
 static const struct slot_table_entry p9dsu2uess_phb0_2_slot[] = {
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0,0),
 		.name = "UIO Slot3",
 		.power_limit = 75,
@@ -492,7 +492,7 @@ static const struct slot_table_entry p9dsu2uess_phb8_1_slot[] = {
 
 static const struct slot_table_entry p9dsu2uess_phb8_2_slot[] = {
 	{
-		.etype = st_builtin_dev,
+		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0,0),
 		.children = p9dsu2uess_wio_plx_up,
 		.name = "PLX WIO Slot3",
@@ -506,6 +506,16 @@ static const struct slot_table_entry p9dsu2uess_phb8_3_slot[] = {
 		.etype = st_pluggable_slot,
 		.location = ST_LOC_DEVFN(0,0),
 		.name = "WIO Slot4",
+		.power_limit = 75,
+	},
+	{ .etype = st_end },
+};
+
+static const struct slot_table_entry p9dsu2uess_phb8_4_slot[] = {
+	{
+		.etype = st_pluggable_slot,
+		.location = ST_LOC_DEVFN(0,0),
+		.name = "WIO Slot5",
 		.power_limit = 75,
 	},
 	{ .etype = st_end },
@@ -557,10 +567,15 @@ static const struct slot_table_entry p9dsu2uess_phb_table[] = {
 		.location = ST_LOC_PHB(8,2),
 		.children = p9dsu2uess_phb8_2_slot,
 	},
-		{
+	{
 		.etype = st_phb,
 		.location = ST_LOC_PHB(8,3),
 		.children = p9dsu2uess_phb8_3_slot,
+	},
+	{
+		.etype = st_phb,
+		.location = ST_LOC_PHB(8,4),
+		.children = p9dsu2uess_phb8_4_slot,
 	},
 	{ .etype = st_end },
 };


### PR DESCRIPTION
Set the attributes on the slot tables to account for
builtin or pluggable etypes, this will allow pci
enumeration to calculate subordinate buses.

Update some slot label strings.

Add WIO Slot5 which is standard on the ESS config.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>