### PR TITLE
[stable branch] skiboot 6.0.x

### DIFF
--- a/core/ipmi.c
+++ b/core/ipmi.c
@@ -147,7 +147,8 @@ void ipmi_cmd_done(uint8_t cmd, uint8_t netfn, uint8_t cc, struct ipmi_msg *msg)
 	msg->netfn = netfn;
 
 	if (cc != IPMI_CC_NO_ERROR) {
-		prlog(PR_DEBUG, "IPMI: Got error response 0x%02x\n", msg->cc);
+		prlog(PR_DEBUG, "IPMI: Got error response. cmd=0x%x, netfn=0x%x,"
+		      " rc=0x%02x\n", msg->cmd, msg->netfn, msg->cc);
 
 		assert(msg->error);
 		msg->error(msg);

--- a/core/opal.c
+++ b/core/opal.c
@@ -187,8 +187,8 @@ int64_t opal_exit_check(int64_t retval, struct stack_frame *eframe)
 			abort();
 		}
 		if (!list_empty(&cpu->locks_held)) {
-			prlog(PR_ERR, "OPAL exiting with locks held, token=%llu retval=%lld\n",
-			      token, retval);
+			prlog(PR_ERR, "OPAL exiting with locks held, pir=%04x token=%llu retval=%lld\n",
+			      cpu->pir, token, retval);
 			drop_my_locks(true);
 		}
 	}

--- a/hdata/memory.c
+++ b/hdata/memory.c
@@ -448,7 +448,9 @@ static void add_memory_controller(const struct HDIF_common_hdr *msarea,
 	if (!mcbist) {
 		mcbist = dt_new_addr(xscom, "mcbist", mcbist_id);
 		assert(mcbist);
-		dt_add_mem_reg_property(mcbist, mcbist_id);
+		dt_add_property_cells(mcbist, "#address-cells", 1);
+		dt_add_property_cells(mcbist, "#size-cells", 0);
+		dt_add_property_cells(mcbist, "reg", mcbist_id, 0);
 	}
 
 	mcs_id = MS_CONTROLLER_MCS_ID(controller_id);


### PR DESCRIPTION
@stewart-ibm 

This PR contains three trivial fixes but useful for debugging issues.

One fixes device tree warnings. and Two other are useful for debugging.

When I sent patches to upstream, I didn't CC stable. But these patches helped while debugging some of the hardlock and ipmi error messages. So decided to backport them to stable branches.

-Vasant

