### PR TITLE
libflash/ecc: Fix compilation warning

### DIFF
--- a/libflash/ecc.c
+++ b/libflash/ecc.c
@@ -177,7 +177,7 @@ static int eccbyte(uint64_t *dst, struct ecc64 *src)
 	return 0;
 }
 
-static uint64_t *inc_uint64_by(const uint64_t *p, uint64_t i)
+static uint64_t *inc_uint64_by(const void *p, uint64_t i)
 {
 	return (uint64_t *)(((char *)p) + i);
 }


### PR DESCRIPTION
We are hitting below warning on gcc9.

gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mcpu=power8 -mtune=power8 -fasynchronous-unwind-tables -fstack-clash-protection -O2 -Wall -Werror -Wno-stringop-truncation -I. -c libflash/ecc.c -o libflash-ecc.o
libflash/ecc.c: In function 'memcpy_to_ecc_unaligned':
libflash/ecc.c:419:24: error: taking address of packed member of 'struct ecc64' may result in an unaligned pointer value [-Werror=address-of-packed-member]
  419 |   memcpy(inc_uint64_by(&ecc_word.data, alignment), src, bytes_wanted);
      |                        ^~~~~~~~~~~~~~
libflash/ecc.c:448:24: error: taking address of packed member of 'struct ecc64' may result in an unaligned pointer value [-Werror=address-of-packed-member]
  448 |   memcpy(inc_uint64_by(&ecc_word.data, len), inc_ecc64_by(dst, len),
      |                        ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Fixes: https://github.com/open-power/skiboot/issues/218
Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>
Signed-off-by: Stewart Smith <stewart@linux.ibm.com>