### PR TITLE
libffs: Fix string truncation gcc warning.

### DIFF
--- a/libflash/libffs.c
+++ b/libflash/libffs.c
@@ -522,7 +522,7 @@ int ffs_part_info(struct ffs_handle *ffs, uint32_t part_idx,
 		n = calloc(1, FFS_PART_NAME_MAX + 1);
 		if (!n)
 			return FLASH_ERR_MALLOC_FAILED;
-		strncpy(n, ent->name, FFS_PART_NAME_MAX);
+		strncpy(n, ent->name, FFS_PART_NAME_MAX + 1);
 		*name = n;
 	}
 	return 0;


### PR DESCRIPTION
Allow one more byte copied. The allocated space has extra byte anyway.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>