### PR TITLE
[stable] skiboot 6.3.2

### DIFF
--- a/core/hmi.c
+++ b/core/hmi.c
@@ -672,7 +672,7 @@ static void find_npu2_checkstop_reason(int flat_chip_id,
 	if (!total_errors)
 		return;
 
-	npu2_hmi_verbose = nvram_query_eq("npu2-hmi-verbose", "true");
+	npu2_hmi_verbose = nvram_query_eq_safe("npu2-hmi-verbose", "true");
 	/* Force this for now until we sort out something better */
 	npu2_hmi_verbose = true;
 

--- a/core/init.c
+++ b/core/init.c
@@ -582,7 +582,7 @@ void __noreturn load_and_boot_kernel(bool is_reboot)
 	fsp_console_select_stdout();
 
 	/* Use nvram bootargs over device tree */
-	cmdline = nvram_query("bootargs");
+	cmdline = nvram_query_safe("bootargs");
 	if (cmdline) {
 		dt_check_del_prop(dt_chosen, "bootargs");
 		dt_add_property_string(dt_chosen, "bootargs", cmdline);
@@ -740,7 +740,7 @@ static void console_log_level(void)
 
 	/* console log level:
 	 *   high 4 bits in memory, low 4 bits driver (e.g. uart). */
-	s = nvram_query("log-level-driver");
+	s = nvram_query_safe("log-level-driver");
 	if (s) {
 		level = console_get_level(s);
 		debug_descriptor.console_log_levels =
@@ -749,7 +749,7 @@ static void console_log_level(void)
 		prlog(PR_NOTICE, "console: Setting driver log level to %i\n",
 		      level & 0x0f);
 	}
-	s = nvram_query("log-level-memory");
+	s = nvram_query_safe("log-level-memory");
 	if (s) {
 		level = console_get_level(s);
 		debug_descriptor.console_log_levels =
@@ -867,7 +867,7 @@ static void pci_nvram_init(void)
 
 	pcie_max_link_speed = 0;
 
-	nvram_speed = nvram_query("pcie-max-link-speed");
+	nvram_speed = nvram_query_dangerous("pcie-max-link-speed");
 	if (nvram_speed) {
 		pcie_max_link_speed = atoi(nvram_speed);
 		prlog(PR_NOTICE, "PHB: NVRAM set max link speed to GEN%i\n",

--- a/core/platform.c
+++ b/core/platform.c
@@ -59,13 +59,13 @@ static int64_t opal_cec_reboot(void)
 
 	opal_quiesce(QUIESCE_HOLD, -1);
 
-	if (proc_gen == proc_gen_p8 && nvram_query_eq("fast-reset","1")) {
+	if (proc_gen == proc_gen_p8 && nvram_query_eq_safe("fast-reset","1")) {
 		/*
 		 * Bugs in P8 mean fast reboot isn't 100% reliable when cores
 		 * are busy, so only attempt if explicitly *enabled*.
 		 */
 		fast_reboot();
-	} else if (!nvram_query_eq("fast-reset","0")) {
+	} else if (!nvram_query_eq_safe("fast-reset","0")) {
 		/* Try fast-reset unless explicitly disabled */
 		fast_reboot();
 	}

--- a/core/test/run-nvram-format.c
+++ b/core/test/run-nvram-format.c
@@ -144,23 +144,23 @@ int main(void)
 
 	/* does an empty partition break us? */
 	data = nvram_reset(nvram_image, 128*1024);
-	assert(nvram_query("test") == NULL);
+	assert(nvram_query_safe("test") == NULL);
 
 	/* does a zero length key break us? */
 	data = nvram_reset(nvram_image, 128*1024);
 	data[0] = '=';
-	assert(nvram_query("test") == NULL);
+	assert(nvram_query_safe("test") == NULL);
 
 	/* does a missing = break us? */
 	data = nvram_reset(nvram_image, 128*1024);
 	data[0] = 'a';
-	assert(nvram_query("test") == NULL);
+	assert(nvram_query_safe("test") == NULL);
 
 	/* does an empty value break us? */
 	data = nvram_reset(nvram_image, 128*1024);
 	data[0] = 'a';
 	data[1] = '=';
-	result = nvram_query("a");
+	result = nvram_query_safe("a");
 	assert(result);
 	assert(strlen(result) == 0);
 
@@ -168,7 +168,7 @@ int main(void)
 	data = nvram_reset(nvram_image, 128*1024);
 #define TEST_1 "a\0a=\0test=test\0"
 	memcpy(data, TEST_1, sizeof(TEST_1));
-	result = nvram_query("test");
+	result = nvram_query_safe("test");
 	assert(result);
 	assert(strcmp(result, "test") == 0);
 

--- a/doc/release-notes/skiboot-6.3.2.rst
+++ b/doc/release-notes/skiboot-6.3.2.rst
@@ -1,0 +1,219 @@
+.. _skiboot-6.3.2:
+
+==============
+skiboot-6.3.2
+==============
+
+skiboot 6.3.2 was released on Monday July 1st, 2019. It replaces
+:ref:`skiboot-6.3.1` as the current stable release in the 6.3.x series.
+
+It is recommended that 6.3.2 be used instead of 6.3.1 version due to the
+bug fixes it contains.
+
+Bug fixes included in this release are:
+
+- npu2: Purge cache when resetting a GPU
+
+  After putting all a GPU's links in reset, do a cache purge in case we
+  have CPU cache lines belonging to the now-unaccessible GPU memory.
+
+- npu2: Reset NVLinks when resetting a GPU
+
+  Resetting a V100 GPU brings its NVLinks down and if an NPU tries using
+  those, an HMI occurs. We were lucky not to observe this as the bare metal
+  does not normally reset a GPU and when passed through, GPUs are usually
+  before NPUs in QEMU command line or Libvirt XML and because of that NPUs
+  are naturally reset first. However simple change of the device order
+  brings HMIs.
+
+  This defines a bus control filter for a PCI slot with a GPU with NVLinks
+  so when the host system issues secondary bus reset to the slot, it resets
+  associated NVLinks.
+
+- hw/phb4: Assert Link Disable bit after ETU init
+
+  The cursed RAID card in ozrom1 has a bug where it ignores PERST being
+  asserted. The PCIe Base spec is a little vague about what happens
+  while PERST is asserted, but it does clearly specify that when
+  PERST is de-asserted the Link Training and Status State Machine
+  (LTSSM) of a device should return to the initial state (Detect)
+  defined in the spec and the link training process should restart.
+
+  This bug was worked around in 9078f8268922 ("phb4: Delay training till
+  after PERST is deasserted") by setting the link disable bit at the
+  start of the FRESET process and clearing it after PERST was
+  de-asserted. Although this fixed the bug, the patch offered no
+  explaination of why the fix worked.
+
+  In b8b4c79d4419 ("hw/phb4: Factor out PERST control") the link disable
+  workaround was moved into phb4_assert_perst(). This is called
+  always in the CRESET case, but a following patch resulted in
+  assert_perst() not being called if phb4_freset() was entered following a
+  CRESET since p->skip_perst was set in the CRESET handler. This is bad
+  since a side-effect of the CRESET is that the Link Disable bit is
+  cleared.
+
+  This, combined with the RAID card ignoring PERST results in the PCIe
+  link being trained by the PHB while we're waiting out the 100ms
+  ETU reset time. If we hack skiboot to print a DLP trace after returning
+  from phb4_hw_init() we get: ::
+
+   PHB#0001[0:1]: Initialization complete
+   PHB#0001[0:1]: TRACE:0x0000102101000000  0ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000001101000000 23ms          GEN1:x16:detect
+   PHB#0001[0:1]: TRACE:0x0000102101000000 23ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000183101000000 29ms training GEN1:x16:config
+   PHB#0001[0:1]: TRACE:0x00001c5881000000 30ms training GEN1:x08:recovery
+   PHB#0001[0:1]: TRACE:0x00001c5883000000 30ms training GEN3:x08:recovery
+   PHB#0001[0:1]: TRACE:0x0000144883000000 33ms presence GEN3:x08:L0
+   PHB#0001[0:1]: TRACE:0x0000154883000000 33ms trained  GEN3:x08:L0
+   PHB#0001[0:1]: CRESET: wait_time = 100
+   PHB#0001[0:1]: FRESET: Starts
+   PHB#0001[0:1]: FRESET: Prepare for link down
+   PHB#0001[0:1]: FRESET: Assert skipped
+   PHB#0001[0:1]: FRESET: Deassert
+   PHB#0001[0:1]: TRACE:0x0000154883000000  0ms trained  GEN3:x08:L0
+   PHB#0001[0:1]: TRACE: Reached target state
+   PHB#0001[0:1]: LINK: Start polling
+   PHB#0001[0:1]: LINK: Electrical link detected
+   PHB#0001[0:1]: LINK: Link is up
+   PHB#0001[0:1]: LINK: Went down waiting for stabilty
+   PHB#0001[0:1]: LINK: DLP train control: 0x0000105101000000
+   PHB#0001[0:1]: CRESET: Starts
+
+  What has happened here is that the link is trained to 8x Gen3 33ms after
+  we return from phb4_init_hw(), and before we've waitined to 100ms
+  that we normally wait after re-initialising the ETU. When we "deassert"
+  PERST later on in the FRESET handler the link in L0 (normal) state. At
+  this point we try to read from the Vendor/Device ID register to verify
+  that the link is stable and immediately get a PHB fence due to a PCIe
+  Completion Timeout. Skiboot attempts to recover by doing another CRESET,
+  but this will encounter the same issue.
+
+  This patch fixes the problem by setting the Link Disable bit (by calling
+  phb4_assert_perst()) immediately after we return from phb4_init_hw().
+  This prevents the link from being trained while PERST is asserted which
+  seems to avoid the Completion Timeout. With the patch applied we get: ::
+
+   PHB#0001[0:1]: Initialization complete
+   PHB#0001[0:1]: TRACE:0x0000102101000000  0ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000001101000000 23ms          GEN1:x16:detect
+   PHB#0001[0:1]: TRACE:0x0000102101000000 23ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000909101000000 29ms presence GEN1:x16:disabled
+   PHB#0001[0:1]: CRESET: wait_time = 100
+   PHB#0001[0:1]: FRESET: Starts
+   PHB#0001[0:1]: FRESET: Prepare for link down
+   PHB#0001[0:1]: FRESET: Assert skipped
+   PHB#0001[0:1]: FRESET: Deassert
+   PHB#0001[0:1]: TRACE:0x0000001101000000  0ms          GEN1:x16:detect
+   PHB#0001[0:1]: TRACE:0x0000102101000000  0ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000001101000000 24ms          GEN1:x16:detect
+   PHB#0001[0:1]: TRACE:0x0000102101000000 36ms presence GEN1:x16:polling
+   PHB#0001[0:1]: TRACE:0x0000183101000000 97ms training GEN1:x16:config
+   PHB#0001[0:1]: TRACE:0x00001c5881000000 97ms training GEN1:x08:recovery
+   PHB#0001[0:1]: TRACE:0x00001c5883000000 97ms training GEN3:x08:recovery
+   PHB#0001[0:1]: TRACE:0x0000144883000000 99ms presence GEN3:x08:L0
+   PHB#0001[0:1]: TRACE: Reached target state
+   PHB#0001[0:1]: LINK: Start polling
+   PHB#0001[0:1]: LINK: Electrical link detected
+   PHB#0001[0:1]: LINK: Link is up
+   PHB#0001[0:1]: LINK: Link is stable
+   PHB#0001[0:1]: LINK: Card [9005:028c] Optimal Retry:disabled
+   PHB#0001[0:1]: LINK: Speed Train:GEN3 PHB:GEN4 DEV:GEN3
+   PHB#0001[0:1]: LINK: Width Train:x08 PHB:x08 DEV:x08
+   PHB#0001[0:1]: LINK: RX Errors Now:0 Max:8 Lane:0x0000
+
+- npu2: Reset PID wildcard and refcounter when mapped to LPID
+
+  Since 105d80f85b "npu2: Use unfiltered mode in XTS tables" we do not
+  register every PID in the XTS table so the table has one entry per LPID.
+  Then we added a reference counter to keep track of the entry use when
+  switching GPU between the host and guest systems (the "Fixes:" tag below).
+
+  The POWERNV platform setup creates such entries and references them
+  at the boot time when initializing IOMMUs and only removes it when
+  a GPU is passed through to a guest. This creates a problem as POWERNV
+  boots via kexec and no defererencing happens; the XTS table state remains
+  undefined. So when the host kernel boots, skiboot thinks there are valid
+  XTS entries and does not update the XTS table which breaks ATS.
+
+  This adds the reference counter and the XTS entry reset when a GPU is
+  assigned to LPID and we cannot rely on the kernel to clean that up.
+
+- hw/phb4: Use read/write_reg in assert_perst
+
+  While the PHB is fenced we can't use the MMIO interface to access PHB
+  registers. While processing a complete reset we inject a PHB fence to
+  isolate the PHB from the rest of the system because the PHB won't
+  respond to MMIOs from the rest of the system while being reset.
+
+  We assert PERST after the fence has been erected which requires us to
+  use the XSCOM indirect interface to access the PHB registers rather than
+  the MMIO interface. Previously we did that when asserting PERST in the
+  CRESET path. However in b8b4c79d4419 ("hw/phb4: Factor out PERST
+  control"). This was re-written to use the raw in_be64() accessor. This
+  means that CRESET would not be asserted in the reset path. On some
+  Mellanox cards this would prevent them from re-loading their firmware
+  when the system was fast-reset.
+
+  This patch fixes the problem by replacing the raw {in|out}_be64()
+  accessors with the phb4_{read|write}_reg() functions.
+
+- opal-prd: Fix prd message size issue
+
+  If prd messages size is insufficient then read_prd_msg() call fails with
+  below error. And caller is not reallocating sufficient buffer. Also its
+  hard to guess the size.
+
+  sample log:::
+  -----------
+  Mar 28 03:31:43 zz24p1 opal-prd: FW: error reading from firmware: alloc 32 rc -1: Invalid argument
+  Mar 28 03:31:43 zz24p1 opal-prd: FW: error reading from firmware: alloc 32 rc -1: Invalid argument
+  Mar 28 03:31:43 zz24p1 opal-prd: FW: error reading from firmware: alloc 32 rc -1: Invalid argument
+  ....
+
+  Lets use opal-msg-size device tree property to allocate memory
+  for prd message.
+
+- npu2: Fix clearing the FIR bits
+
+  FIR registers are SCOM-only so they cannot be accesses with the indirect
+  write, and yet we use SCOM-based addresses for these; fix this.
+
+- opal-gard: Account for ECC size when clearing partition
+
+  When 'opal-gard clear all' is run, it works by erasing the GUARD then
+  using blockevel_smart_write() to write nothing to the partition. This
+  second write call is needed because we rely on libflash to set the ECC
+  bits appropriately when the partition contained ECCed data.
+
+  The API for this is a little odd with the caller specifying how much
+  actual data to write, and libflash writing size + size/8 bytes
+  since there is one additional ECC byte for every eight bytes of data.
+
+  We currently do not account for the extra space consumed by the ECC data
+  in reset_partition() which is used to handle the 'clear all' command.
+  Which results in the paritition following the GUARD partition being
+  partially overwritten when the command is used. This patch fixes the
+  problem by reducing the length we would normally write by the number
+  of ECC bytes required.
+
+- nvram: Flag dangerous NVRAM options
+
+  Most nvram options used by skiboot are just for debug or testing for
+  regressions. They should never be used long term.
+
+  We've hit a number of issues in testing and the field where nvram
+  options have been set "temporarily" but haven't been properly cleared
+  after, resulting in crashes or real bugs being masked.
+
+  This patch marks most nvram options used by skiboot as dangerous and
+  prints a chicken to remind users of the problem.
+
+- devicetree: Don't set path to dtc in makefile
+
+  By setting the path we fail to build under buildroot which has it's own
+  set of host tools in PATH, but not at /usr/bin.
+
+  Keep the variable so it can be set if need be but default to whatever
+  'dtc' is in the users path.

--- a/external/devicetree/Makefile
+++ b/external/devicetree/Makefile
@@ -1,4 +1,4 @@
-DTC=/usr/bin/dtc
+DTC=dtc
 OUT=p9-simics.dtb
 
 all: $(OUT)

--- a/external/gard/gard.c
+++ b/external/gard/gard.c
@@ -598,6 +598,7 @@ static int do_clear_i(struct gard_ctx *ctx, int pos, struct gard_record *gard, v
 
 static int reset_partition(struct gard_ctx *ctx)
 {
+	int no_ecc_len = (ctx->gard_data_len / 9) * 8;
 	struct gard_record *gard;
 	int rc = 0;
 
@@ -613,7 +614,7 @@ static int reset_partition(struct gard_ctx *ctx)
 		goto out;
 	}
 
-	rc = blocklevel_write(ctx->bl, ctx->gard_data_pos, gard, ctx->gard_data_len);
+	rc = blocklevel_write(ctx->bl, ctx->gard_data_pos, gard, no_ecc_len);
 	if (rc)
 		fprintf(stderr, "Couldn't reset the entire gard partition. Bailing out\n");
 

--- a/external/opal-prd/opal-prd.c
+++ b/external/opal-prd/opal-prd.c
@@ -2120,7 +2120,9 @@ static int init_control_socket(struct opal_prd_ctx *ctx)
 
 static int run_prd_daemon(struct opal_prd_ctx *ctx)
 {
-	int rc;
+	char *opal_msg_path;
+	void *buf;
+	int rc, len;
 
 	/* log to syslog */
 	pr_log_daemon_init();
@@ -2130,14 +2132,31 @@ static int run_prd_daemon(struct opal_prd_ctx *ctx)
 	ctx->fd = -1;
 	ctx->socket = -1;
 
-	/* set up our message buffer */
-	ctx->msg_alloc_len = sizeof(*ctx->msg);
+	/*
+	 * Set up our message buffer. Use opal-msg-size device tree
+	 * property to get message buffer size.
+	 */
+	rc = asprintf(&opal_msg_path,
+		       "%s/ibm,opal/opal-msg-size", devicetree_base);
+	if (rc > 0) {
+		rc = open_and_read(opal_msg_path, &buf, &len);
+		if (rc == 0) {
+			ctx->msg_alloc_len = be32toh(*(__be32 *)buf);
+			free(buf);
+		}
+
+		free(opal_msg_path);
+	}
+
+	if (ctx->msg_alloc_len == 0)
+		ctx->msg_alloc_len = sizeof(*ctx->msg);
+
 	ctx->msg = malloc(ctx->msg_alloc_len);
 	if (!ctx->msg) {
 		pr_log(LOG_ERR, "FW: Can't allocate PRD message buffer: %m");
 		return -1;
 	}
-
+	memset(ctx->msg, 0, ctx->msg_alloc_len);
 
 	list_head_init(&ctx->msgq);
 

--- a/hw/lpc-uart.c
+++ b/hw/lpc-uart.c
@@ -506,7 +506,7 @@ static void uart_init_opal_console(void)
 	/* Update the policy if the corresponding nvram variable
 	 * is present
 	 */
-	nv_policy = nvram_query("uart-con-policy");
+	nv_policy = nvram_query_dangerous("uart-con-policy");
 	if (nv_policy) {
 		if (!strcmp(nv_policy, "opal"))
 			uart_console_policy = UART_CONSOLE_OPAL;

--- a/hw/npu2-common.c
+++ b/hw/npu2-common.c
@@ -663,7 +663,7 @@ void probe_npu2(void)
 	}
 
 	/* Check for a zcal override */
-	zcal = nvram_query("nv_zcal_override");
+	zcal = nvram_query_dangerous("nv_zcal_override");
 	if (zcal) {
 		nv_zcal_nominal = atoi(zcal);
 		prlog(PR_WARNING, "NPU2: Using ZCAL impedance override = %d\n", nv_zcal_nominal);

--- a/hw/npu2-hw-procedures.c
+++ b/hw/npu2-hw-procedures.c
@@ -331,7 +331,7 @@ static uint32_t reset_ntl_release(struct npu2_dev *ndev)
 	npu2_fir = 0;
 
 	for (i = 0; i < NPU2_TOTAL_FIR_REGISTERS; i++) {
-		npu2_write(ndev->npu, npu2_fir_addr, npu2_fir);
+		xscom_write(ndev->npu->chip_id, npu2_fir_addr, npu2_fir);
 		npu2_fir_addr += NPU2_FIR_OFFSET;
 
 	}

--- a/hw/npu2-opencapi.c
+++ b/hw/npu2-opencapi.c
@@ -1727,7 +1727,7 @@ static void read_nvram_training_state(void)
 {
 	const char *state;
 
-	state = nvram_query("opencapi-link-training");
+	state = nvram_query_dangerous("opencapi-link-training");
 	if (state) {
 		if (!strcmp(state, "prbs31"))
 			npu2_ocapi_training_state = NPU2_TRAIN_PRBS31;

--- a/hw/npu2.c
+++ b/hw/npu2.c
@@ -561,6 +561,8 @@ static int64_t npu2_gpu_brigde_sec_bus_reset(void *dev,
 
 	gpu = list_top(&pd->children, struct pci_device, link);
 	if (gpu && (*data & PCI_CFG_BRCTL_SECONDARY_RESET)) {
+		int64_t rc;
+
 		dt_for_each_compatible(dt_root, np, "ibm,power9-npu-pciex") {
 			npphb = pci_get_phb(dt_prop_get_cell(np,
 					"ibm,opal-phbid", 1));
@@ -574,6 +576,10 @@ static int64_t npu2_gpu_brigde_sec_bus_reset(void *dev,
 					npu2_dev_procedure_reset(ndev);
 			}
 		}
+
+		rc = purge_l2_l3_caches();
+		if (rc)
+			return rc;
 	}
 
 	return OPAL_PARTIAL;

--- a/hw/npu2.c
+++ b/hw/npu2.c
@@ -1473,7 +1473,7 @@ int npu2_nvlink_init_npu(struct npu2 *npu)
 	 * it throws machine checkstop. Disabling snarfing fixes this so let's
 	 * disable it by default.
 	 */
-	if (nvram_query_eq("opal-npu2-snarf-cpm", "enable")) {
+	if (nvram_query_eq_dangerous("opal-npu2-snarf-cpm", "enable")) {
 		prlog(PR_WARNING, "NPU2#%d: enabling Probe.I.MO snarfing, a bad GPU driver may crash the system!\n",
 				npu->index);
 		val |= PPC_BIT(40); /* CONFIG_ENABLE_SNARF_CPM */

--- a/hw/npu2.c
+++ b/hw/npu2.c
@@ -2233,6 +2233,13 @@ static int opal_npu_map_lpar(uint64_t phb_id, uint64_t bdf, uint64_t lparid,
 	NPU2DBG(p, "XTS_BDF_MAP[%03d] = 0x%08llx\n", id, xts_bdf_lpar);
 	npu2_write(p, NPU2_XTS_BDF_MAP + id*8, xts_bdf_lpar);
 
+	/* Reset wildcard in the PID map and the refcounter */
+	if (npu2_read(p, NPU2_XTS_PID_MAP + id*0x20) || p->ctx_ref[id]) {
+		prlog(PR_INFO, "Resetting PID MAP for LPID %lld\n", lparid);
+		p->ctx_ref[id] = 0;
+		npu2_write(p, NPU2_XTS_PID_MAP + id*0x20, 0);
+	}
+
 out:
 	unlock(&p->lock);
 	return rc;

--- a/hw/phb4.c
+++ b/hw/phb4.c
@@ -2892,7 +2892,7 @@ static void phb4_assert_perst(struct pci_slot *slot, bool assert)
 	 * bit in the btctl register also works.
 	 */
 	phb4_pcicfg_read16(&p->phb, 0, p->ecap + PCICAP_EXP_LCTL, &linkctl);
-	reg = in_be64(p->regs + PHB_PCIE_CRESET);
+	reg = phb4_read_reg(p, PHB_PCIE_CRESET);
 
 	if (assert) {
 		linkctl |= PCICAP_EXP_LCTL_LINK_DIS;
@@ -2902,7 +2902,7 @@ static void phb4_assert_perst(struct pci_slot *slot, bool assert)
 		reg |= PHB_PCIE_CRESET_PERST_N;
 	}
 
-	out_be64(p->regs + PHB_PCIE_CRESET, reg);
+	phb4_write_reg(p, PHB_PCIE_CRESET, reg);
 	phb4_pcicfg_write16(&p->phb, 0, p->ecap + PCICAP_EXP_LCTL, linkctl);
 }
 

--- a/hw/phb4.c
+++ b/hw/phb4.c
@@ -5919,16 +5919,16 @@ void probe_phb4(void)
 	struct dt_node *np;
 	const char *s;
 
-	verbose_eeh = nvram_query_eq("pci-eeh-verbose", "true");
+	verbose_eeh = nvram_query_eq_safe("pci-eeh-verbose", "true");
 	/* REMOVEME: force this for now until we stabalise PCIe */
 	verbose_eeh = 1;
 	if (verbose_eeh)
 		prlog(PR_INFO, "PHB4: Verbose EEH enabled\n");
 
-	pci_tracing = nvram_query_eq("pci-tracing", "true");
-	pci_eeh_mmio = !nvram_query_eq("pci-eeh-mmio", "disabled");
-	pci_retry_all = nvram_query_eq("pci-retry-all", "true");
-	s = nvram_query("phb-rx-err-max");
+	pci_tracing = nvram_query_eq_safe("pci-tracing", "true");
+	pci_eeh_mmio = !nvram_query_eq_dangerous("pci-eeh-mmio", "disabled");
+	pci_retry_all = nvram_query_eq_dangerous("pci-retry-all", "true");
+	s = nvram_query_dangerous("phb-rx-err-max");
 	if (s) {
 		rx_err_max = atoi(s);
 
@@ -5937,7 +5937,6 @@ void probe_phb4(void)
 		rx_err_max = MIN(rx_err_max, 255);
 	}
 	prlog(PR_DEBUG, "PHB4: Maximum RX errors during training: %d\n", rx_err_max);
-
 	/* Look for PBCQ XSCOM nodes */
 	dt_for_each_compatible(dt_root, np, "ibm,power9-pbcq")
 		phb4_probe_pbcq(np);

--- a/hw/phb4.c
+++ b/hw/phb4.c
@@ -3344,6 +3344,12 @@ static int64_t phb4_creset(struct pci_slot *slot)
 		pci_slot_set_state(slot, PHB4_SLOT_CRESET_FRESET);
 
 		/*
+		 * The PERST is sticky across resets, but LINK_DIS isn't.
+		 * Re-assert it here now that we've reset the PHB.
+		 */
+		phb4_assert_perst(slot, true);
+
+		/*
 		 * wait either 100ms (for the ETU logic) or until we've had
 		 * PERST asserted for 250ms.
 		 */

--- a/hw/slw.c
+++ b/hw/slw.c
@@ -883,7 +883,7 @@ void add_cpu_idle_state_properties(void)
 		if (wakeup_engine_state == WAKEUP_ENGINE_PRESENT)
 			supported_states_mask |= OPAL_PM_WINKLE_ENABLED;
 	}
-	nvram_disable_str = nvram_query("opal-stop-state-disable-mask");
+	nvram_disable_str = nvram_query_dangerous("opal-stop-state-disable-mask");
 	if (nvram_disable_str)
 		nvram_disabled_states_mask = strtol(nvram_disable_str, NULL, 0);
 	prlog(PR_DEBUG, "NVRAM stop disable mask: %x\n", nvram_disabled_states_mask);

--- a/hw/xscom.c
+++ b/hw/xscom.c
@@ -833,7 +833,7 @@ int64_t xscom_trigger_xstop(void)
 	int rc = OPAL_UNSUPPORTED;
 	bool xstop_disabled = false;
 
-	if (nvram_query_eq("opal-sw-xstop", "disable"))
+	if (nvram_query_eq_dangerous("opal-sw-xstop", "disable"))
 		xstop_disabled = true;
 
 	if (xstop_disabled) {

--- a/include/nvram.h
+++ b/include/nvram.h
@@ -24,7 +24,9 @@ bool nvram_validate(void);
 bool nvram_has_loaded(void);
 bool nvram_wait_for_load(void);
 
-const char *nvram_query(const char *name);
-bool nvram_query_eq(const char *key, const char *value);
+const char *nvram_query_safe(const char *name);
+const char *nvram_query_dangerous(const char *name);
+bool nvram_query_eq_safe(const char *key, const char *value);
+bool nvram_query_eq_dangerous(const char *key, const char *value);
 
 #endif /* __NVRAM_H */

--- a/libstb/secureboot.c
+++ b/libstb/secureboot.c
@@ -104,7 +104,7 @@ void secureboot_init(void)
 
 	prlog(PR_DEBUG, "Found %s\n", compat);
 
-	if (nvram_query_eq("force-secure-mode", "always")) {
+	if (nvram_query_eq_dangerous("force-secure-mode", "always")) {
 		secure_mode = true;
 		prlog(PR_NOTICE, "secure mode on (FORCED by nvram)\n");
 	} else {

--- a/libstb/trustedboot.c
+++ b/libstb/trustedboot.c
@@ -102,7 +102,7 @@ void trustedboot_init(void)
 		return;
 	}
 
-	if (nvram_query_eq("force-trusted-mode", "true")) {
+	if (nvram_query_eq_dangerous("force-trusted-mode", "true")) {
 		trusted_mode = true;
 		prlog(PR_NOTICE, "trusted mode on (FORCED by nvram)\n");
 	} else {


### PR DESCRIPTION
The following changes since commit 990d248a61a077804d75dbfcb99428e16b97db83:

  skiboot v6.3.1 release notes (2019-05-10 16:50:45 +1000)

are available in the Git repository at:

  https://github.com/hegdevasant/skiboot.git

for you to fetch changes up to 7a2b63d5457345c7dd8b6d7d9524b58a0aa0ae5e:

  skiboot v6.3.2 release notes (2019-07-01 15:40:23 +0530)

----------------------------------------------------------------
Alexey Kardashevskiy (3):
      npu2: Fix clearing the FIR bits
      npu2: Reset PID wildcard and refcounter when mapped to LPID
      npu2: Reset NVLinks when resetting a GPU

Joel Stanley (1):
      devicetree: Don't set path to dtc in makefile

Michael Neuling (1):
      nvram: Flag dangerous NVRAM options

Oliver O'Halloran (3):
      opal-gard: Account for ECC size when clearing partition
      hw/phb4: Use read/write_reg in assert_perst
      hw/phb4: Assert Link Disable bit after ETU init

Reza Arbab (1):
      npu2: Purge cache when resetting a GPU

Vasant Hegde (2):
      opal-prd: Fix prd message size issue
      skiboot v6.3.2 release notes

 core/hmi.c                          |   2 +-
 core/init.c                         |   8 +--
 core/nvram-format.c                 |  55 ++++++++++++++++--
 core/platform.c                     |   4 +-
 core/test/run-nvram-format.c        |  10 ++--
 doc/release-notes/skiboot-6.3.2.rst | 219 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 external/devicetree/Makefile        |   2 +-
 external/gard/gard.c                |   3 +-
 external/opal-prd/opal-prd.c        |  27 +++++++--
 hw/lpc-uart.c                       |   2 +-
 hw/npu2-common.c                    |   2 +-
 hw/npu2-hw-procedures.c             |   2 +-
 hw/npu2-opencapi.c                  |   2 +-
 hw/npu2.c                           |  70 +++++++++++++++++++++-
 hw/phb4.c                           |  21 ++++---
 hw/slw.c                            |   2 +-
 hw/xscom.c                          |   2 +-
 include/nvram.h                     |   6 +-
 libstb/secureboot.c                 |   2 +-
 libstb/trustedboot.c                |   2 +-
 20 files changed, 400 insertions(+), 43 deletions(-)
 create mode 100644 doc/release-notes/skiboot-6.3.2.rst

[hegdevasant@hegdevasant skiboot]$ 
