### PR TITLE
6.2.x Fix build with gcc9

### DIFF
--- a/hdata/vpd.c
+++ b/hdata/vpd.c
@@ -328,6 +328,7 @@ static void vpd_vini_parse(struct dt_node *node,
 			   const void *fruvpd, unsigned int fruvpd_sz)
 {
 	const void *kw;
+	const char *desc;
 	uint8_t sz;
 	const struct card_info *cinfo;
 
@@ -381,15 +382,15 @@ static void vpd_vini_parse(struct dt_node *node,
 			dt_add_property_string(node,
 				       "description", cinfo->description);
 		} else {
-			kw = vpd_find(fruvpd, fruvpd_sz, "VINI", "DR", &sz);
-			if (kw) {
+			desc = vpd_find(fruvpd, fruvpd_sz, "VINI", "DR", &sz);
+			if (desc) {
 				dt_add_prop_sanitize_val(node,
-						     "description", kw, sz);
+						     "description", desc, sz);
 			} else {
 				dt_add_property_string(node, "description", "Unknown");
 				prlog(PR_WARNING,
 				      "VPD: CCIN desc not available for: %s\n",
-				      (char *)kw);
+				      (char*)kw);
 			}
 		}
 	}

--- a/include/errorlog.h
+++ b/include/errorlog.h
@@ -119,7 +119,7 @@ struct __attribute__((__packed__))elog_user_data_section {
  * needs to populate this structure using pre-defined interfaces
  * only
  */
-struct __attribute__((__packed__)) errorlog {
+struct __attribute__((__packed__)) __attribute__ ((aligned (8))) errorlog {
 
 	uint16_t component_id;
 	uint8_t error_event_type;

--- a/include/sbe-p9.h
+++ b/include/sbe-p9.h
@@ -205,7 +205,7 @@ struct p9_sbe_msg {
 
 	/* Internal queuing */
 	struct list_node	link;
-} __packed;
+};
 
 
 /* Allocate and populate p9_sbe_msg structure */


### PR DESCRIPTION
[ Upstream commit ef691db3533742d9dd6eed1a311472a7c52be94b ]

Only the reg member is sent anywhere (via xscom_write), so the structure
does not need to be packed.

Fixes GCC9 build problem:
hw/sbe-p9.c: In function ‘p9_sbe_msg_send’:
hw/sbe-p9.c:270:9: error: taking address of packed member of ‘struct p9_sbe_msg’ may result in an unaligned pointer value [-Werror=address-of-packed-member]
  270 |  data = &msg->reg[0];
      |         ^~~~~~~~~~~~

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://open-power.github.io/skiboot/
