### PR TITLE
errorlog: Prevent alignment error building with gcc9.

### DIFF
--- a/include/errorlog.h
+++ b/include/errorlog.h
@@ -119,7 +119,7 @@ struct __attribute__((__packed__))elog_user_data_section {
  * needs to populate this structure using pre-defined interfaces
  * only
  */
-struct __attribute__((__packed__)) errorlog {
+struct __attribute__((__packed__)) __attribute__ ((aligned (8))) errorlog {
 
 	uint16_t component_id;
 	uint8_t error_event_type;


### PR DESCRIPTION
Fixes this build error:
[ 52s] hw/fsp/fsp-elog-write.c: In function 'opal_elog_read':
[ 52s] hw/fsp/fsp-elog-write.c:213:12: error: taking address of packed member of 'struct errorlog' may result in an unaligned pointer value [-Werror=address-of-packed-member]
[ 52s] 213 | list_del(&log_data->link);
[ 52s] | ^~~~~~~~~~~~~~~

Fixes: https://github.com/open-power/skiboot/issues/247
Signed-off-by: Michal Suchanek <msuchanek@suse.de>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://open-power.github.io/skiboot/
