### PR TITLE
Properly check mmap error code

### DIFF
--- a/libstb/print-container.c
+++ b/libstb/print-container.c
@@ -470,7 +470,7 @@ static bool getPayloadHash(int fdin, unsigned char *md)
 
 	payload = mmap(NULL, payload_st.st_size - SECURE_BOOT_HEADERS_SIZE,
 			PROT_READ, MAP_PRIVATE, fdin, SECURE_BOOT_HEADERS_SIZE);
-	if (!payload)
+	if (payload == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file at descriptor: %d (%s)", fdin,
 				strerror(errno));
 


### PR DESCRIPTION
Given that subscribing to you rmailing list does not work I'll send the pull request anyway, despite the warning that I shouldn't.

The check here in the code is wrong. mmap never returns zero, on failure it returns MAP_FAILED (or -1).

There are 2 more cases in the code, however it's less clear to me how to fix them.
In
libstb/create-container.c
there is an mmap call that doesn't seem to check the return value at all.

In extract-gcov.c there's this:
```
	addr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
	assert(addr != NULL);
```
This is doubly wrong, as asserts shouldn't be used for error checking.