### PR TITLE
Check return values of `mmap` calls

### DIFF
--- a/extract-gcov.c
+++ b/extract-gcov.c
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
 	}
 
 	addr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-	assert(addr != NULL);
+	assert(addr != MAP_FAILED);
 	skiboot_dump_size = sb.st_size;
 
 	printf("Skiboot memory dump %p - %p\n",

--- a/libstb/create-container.c
+++ b/libstb/create-container.c
@@ -110,7 +110,7 @@ void getPublicKeyRaw(ecc_key_t *pubkeyraw, char *filename)
 
 		close(fdin);
 
-		if (!infile || (*(unsigned char*) infile != 0x04)) {
+		if (infile == MAP_FAILED || (*(unsigned char*) infile != 0x04)) {
 			die(EX_DATAERR,
 					"File \"%s\" is not in expected format (private or public key in PEM, or public key RAW)",
 					filename);
@@ -148,7 +148,7 @@ void getSigRaw(ecc_signature_t *sigraw, char *filename)
 		die(EX_NOINPUT, "Cannot stat sig file: %s", filename);
 
 	infile = mmap(NULL, s.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	close(fdin);
@@ -464,7 +464,7 @@ int main(int argc, char* argv[])
 		die(EX_NOINPUT, "Cannot stat payload file: %s", params.payloadfn);
 
 	infile = mmap(NULL, payload_st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	fdout = open(params.imagefn, O_WRONLY | O_CREAT | O_TRUNC,

--- a/libstb/print-container.c
+++ b/libstb/print-container.c
@@ -470,7 +470,7 @@ static bool getPayloadHash(int fdin, unsigned char *md)
 
 	payload = mmap(NULL, payload_st.st_size - SECURE_BOOT_HEADERS_SIZE,
 			PROT_READ, MAP_PRIVATE, fdin, SECURE_BOOT_HEADERS_SIZE);
-	if (!payload)
+	if (payload == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file at descriptor: %d (%s)", fdin,
 				strerror(errno));
 
@@ -655,7 +655,7 @@ int main(int argc, char* argv[])
 				strerror(errno));
 
 	container = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!container)
+	if (container == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file: %s (%s)", params.imagefn,
 				strerror(errno));
 


### PR DESCRIPTION
Against all intuition, mmap returns `MAP_FAILED` (-1) instead of `NULL`
in an error case. This commit fixes 3 occurrences of this bug.

One of the bugs was reported in
https://bugs.launchpad.net/qemu/+bug/1879998 and the other two where
found using the script from https://github.com/hannob/mmapfail/

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://open-power.github.io/skiboot/
