### PR TITLE
Properly check mmap error code

### DIFF
--- a/external/ffspart/ffspart.c
+++ b/external/ffspart/ffspart.c
@@ -280,7 +280,7 @@ static int parse_entry(struct blocklevel_device *bl,
 		}
 
 		data_ptr = mmap(NULL, pactual, PROT_READ, MAP_SHARED, data_fd, 0);
-		if (!data_ptr) {
+		if (data_ptr == MAP_FAILED) {
 			fprintf(stderr, "Couldn't mmap file '%s' for '%s' partition "
 				"(%m)\n", filename, name);
 			close(data_fd);

--- a/libstb/create-container.c
+++ b/libstb/create-container.c
@@ -95,7 +95,7 @@ void getPublicKeyRaw(ecc_key_t *pubkeyraw, char *filename)
 		 * with a leading byte of 0x04, indicating an uncompressed key. */
 		int fdin, r;
 		struct stat s;
-		void *infile = NULL;
+		void *infile = MAP_FAILED;
 
 		fdin = open(filename, O_RDONLY);
 		if (fdin <= 0)
@@ -110,7 +110,7 @@ void getPublicKeyRaw(ecc_key_t *pubkeyraw, char *filename)
 
 		close(fdin);
 
-		if (!infile || (*(unsigned char*) infile != 0x04)) {
+		if ( (infile==MAP_FAILED) || (*(unsigned char*) infile != 0x04)) {
 			die(EX_DATAERR,
 					"File \"%s\" is not in expected format (private or public key in PEM, or public key RAW)",
 					filename);
@@ -148,7 +148,7 @@ void getSigRaw(ecc_signature_t *sigraw, char *filename)
 		die(EX_NOINPUT, "Cannot stat sig file: %s", filename);
 
 	infile = mmap(NULL, s.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	close(fdin);
@@ -464,7 +464,7 @@ int main(int argc, char* argv[])
 		die(EX_NOINPUT, "Cannot stat payload file: %s", params.payloadfn);
 
 	infile = mmap(NULL, payload_st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	fdout = open(params.imagefn, O_WRONLY | O_CREAT | O_TRUNC,

--- a/libstb/print-container.c
+++ b/libstb/print-container.c
@@ -655,7 +655,7 @@ int main(int argc, char* argv[])
 				strerror(errno));
 
 	container = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!container)
+	if (container == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file: %s (%s)", params.imagefn,
 				strerror(errno));
 


### PR DESCRIPTION
This PR fixes five places where the return value of mmap was handled wrong. I was able to spot another one,but there is already a pull request for this issue (https://github.com/open-power/skiboot/pull/252) .

Best regards from the Cppcheck team
