### PR TITLE
collected mmap fixes

### DIFF
--- a/libstb/create-container.c
+++ b/libstb/create-container.c
@@ -95,7 +95,7 @@ void getPublicKeyRaw(ecc_key_t *pubkeyraw, char *filename)
 		 * with a leading byte of 0x04, indicating an uncompressed key. */
 		int fdin, r;
 		struct stat s;
-		void *infile = NULL;
+		void *infile = MAP_FAILED;
 
 		fdin = open(filename, O_RDONLY);
 		if (fdin <= 0)
@@ -110,7 +110,7 @@ void getPublicKeyRaw(ecc_key_t *pubkeyraw, char *filename)
 
 		close(fdin);
 
-		if (!infile || (*(unsigned char*) infile != 0x04)) {
+		if ((infile == MAP_FAILED) || (*(unsigned char*) infile != 0x04)) {
 			die(EX_DATAERR,
 					"File \"%s\" is not in expected format (private or public key in PEM, or public key RAW)",
 					filename);
@@ -148,7 +148,7 @@ void getSigRaw(ecc_signature_t *sigraw, char *filename)
 		die(EX_NOINPUT, "Cannot stat sig file: %s", filename);
 
 	infile = mmap(NULL, s.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	close(fdin);
@@ -464,7 +464,7 @@ int main(int argc, char* argv[])
 		die(EX_NOINPUT, "Cannot stat payload file: %s", params.payloadfn);
 
 	infile = mmap(NULL, payload_st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!infile)
+	if (infile == MAP_FAILED)
 		die(EX_OSERR, "%s", "Cannot mmap file");
 
 	fdout = open(params.imagefn, O_WRONLY | O_CREAT | O_TRUNC,

--- a/libstb/print-container.c
+++ b/libstb/print-container.c
@@ -655,7 +655,7 @@ int main(int argc, char* argv[])
 				strerror(errno));
 
 	container = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fdin, 0);
-	if (!container)
+	if (container == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file: %s (%s)", params.imagefn,
 				strerror(errno));
 

--- a/libstb/print-container.c
+++ b/libstb/print-container.c
@@ -470,7 +470,7 @@ static bool getPayloadHash(int fdin, unsigned char *md)
 
 	payload = mmap(NULL, payload_st.st_size - SECURE_BOOT_HEADERS_SIZE,
 			PROT_READ, MAP_PRIVATE, fdin, SECURE_BOOT_HEADERS_SIZE);
-	if (!payload)
+	if (payload == MAP_FAILED)
 		die(EX_OSERR, "Cannot mmap file at descriptor: %d (%s)", fdin,
 				strerror(errno));
 


### PR DESCRIPTION
The fixes to ffspart in #255 broke the tests for ffspart and pflash because both of them attempt to use /dev/zero and /dev/urandom as input files. The current implementation for ffspart uses the file size returned by stat() to determine the mmap() mapping length. However, the size is zero leading to mmap() failing with EINVAL. For dumb reasons the test still passed and the patch to add proper return code checking uncovered the breakage. 

Good stuff all around IMO.

Includes the fixes from #252 and #255.
