### PR TITLE
Skiboot 6.0.x

### DIFF
--- a/doc/release-notes/skiboot-6.0.24.rst
+++ b/doc/release-notes/skiboot-6.0.24.rst
@@ -1,0 +1,22 @@
+.. _skiboot-6.0.24:
+
+==============
+skiboot-6.0.24
+==============
+
+skiboot 6.0.24 was released on Wednesday September 29th, 2021. It replaces
+:ref:`skiboot-6.0.23` as the current stable release in the 6.0.x series.
+
+It is recommended that 6.0.24 be used instead of any previous 6.0.x version
+due to the bug fixes it contains.
+
+Bug fixes included in this release are:
+
+- phb4: Disable TCE cache line buffer
+
+- SBE: Check timer state before scheduling timer
+
+- SBE: Rate limit timer requests
+
+- SBE: Account cancelled timer request
+

--- a/hw/phb4.c
+++ b/hw/phb4.c
@@ -4822,6 +4822,7 @@ static void phb4_init_hw(struct phb4 *p, bool first_init)
 
 	/* Init_17 - PHB Control */
 	val = PHB_CTRLR_IRQ_PGSZ_64K;
+	val |= PHB_CTRLR_TCE_CLB_DISABLE; // HW557787 circumvention
 	if (p->rev == PHB4_REV_NIMBUS_DD10) {
 		val |= SETFIELD(PHB_CTRLR_TVT_ADDR_SEL, 0ull, TVT_DD1_2_PER_PE);
 	} else {

--- a/hw/sbe-p9.c
+++ b/hw/sbe-p9.c
@@ -809,6 +809,9 @@ static void p9_sbe_timer_schedule(void)
 	u64 tb_cnt, now = mftb();
 
 	if (sbe_timer_in_progress) {
+		if (sbe_timer_target >= sbe_last_gen_stamp)
+			return;
+
 		if (now >= sbe_last_gen_stamp)
 			return;
 

--- a/hw/sbe-p9.c
+++ b/hw/sbe-p9.c
@@ -777,8 +777,10 @@ static void p9_sbe_timer_resp(struct p9_sbe_msg *msg)
 
 	lock(&sbe_timer_lock);
 	if (has_new_target) {
-		has_new_target = false;
-		p9_sbe_timer_schedule();
+		if (!p9_sbe_msg_busy(timer_ctrl_msg)) {
+			has_new_target = false;
+			p9_sbe_timer_schedule();
+		}
 	}
 	unlock(&sbe_timer_lock);
 }

--- a/include/phb4-regs.h
+++ b/include/phb4-regs.h
@@ -144,6 +144,7 @@
 #define     TVT_4_PER_PE		1
 #define     TVT_8_PER_PE		2
 #define     TVT_16_PER_PE		3
+#define   PHB_CTRLR_TCE_CLB_DISABLE	PPC_BIT(21)
 #define   PHB_CTRLR_DMA_RD_SPACING	PPC_BITMASK(28,31)
 #define PHB_AIB_FENCE_CTRL		0x860
 #define PHB_TCE_TAG_ENABLE		0x868


### PR DESCRIPTION
Bug fixes included in this release are:
- phb4: Disable TCE cache line buffer
- SBE: Check timer state before scheduling timer
- SBE: Rate limit timer requests
- SBE: Account cancelled timer request
