### PR TITLE
Makefile: Link final elf with -z notext for newer binutils

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -197,6 +197,10 @@ LDFLAGS_FINAL = -m elf64lppc --no-multi-toc -N --build-id=none --whole-archive
 LDFLAGS_FINAL += -static -nostdlib -pie -Ttext-segment=$(LD_TEXT) --oformat=elf64-powerpc
 LDFLAGS_FINAL += --orphan-handling=warn
 LDFLAGS_FINAL += $(call try-ldflag,$(LD),--no-warn-rwx-segments)
+# skiboot is a self-relocating PIE and processes its own relocations at boot,
+# so it legitimately has text relocations. binutils >= 2.39 turns "read-only
+# segment has dynamic relocations" into a hard error by default; allow it.
+LDFLAGS_FINAL += $(call try-ldflag,$(LD),-z notext)
 
 LDRFLAGS=-melf64ppc
 # Debug stuff


### PR DESCRIPTION
skiboot is a self-relocating PIE: it links with `-pie` and processes its own relocations at boot, so it legitimately contains text relocations.

binutils >= 2.39 promotes *"read-only segment has dynamic relocations"* from a warning to a hard error by default, which breaks the final link:

```
ld: error: read-only segment has dynamic relocations
```

This is hit with binutils 2.46 (Fedora 44, Ubuntu 26.04) and 2.44 (Debian 13). Pass `-z notext` to allow the text relocations, guarded by `try-ldflag` to match the existing `--no-warn-rwx-segments` handling added in 3d634a14.